### PR TITLE
Limit fsspec version for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ dynamic = ["version"]
 dependencies = [
   "bioio-base>=0.3.0",
   "dask[array]>=2021.4.1",
-  "fsspec>=2022.8.0",
+  # fssspec restricted due to glob issue tracked here, when fixed remove ceiling
+  # https://github.com/fsspec/filesystem_spec/issues/1380
+  "fsspec>=2022.8.0,<2023.9.0",
   "numpy>=1.16,<2",
   "PyYAML>=6.0",
   "xarray>=0.16.1",


### PR DESCRIPTION
## Description
This uses the `glob()` function of `fsspec` which seems to be buggy after version `2023.9.0`, limiting the version until a resolution to [this issue](https://github.com/fsspec/filesystem_spec/issues/1380) is reached
