### PR TITLE
use faster yaml loader and better delayed loading

### DIFF
--- a/bioio_sldy/reader.py
+++ b/bioio_sldy/reader.py
@@ -5,6 +5,7 @@ import logging
 import pathlib
 import typing
 
+import dask
 import dask.array as da
 import numpy as np
 import xarray as xr
@@ -149,8 +150,13 @@ class Reader(reader.Reader):
         for timepoint in timepoints:
             data_for_timepoint: typing.List[da.Array] = []
             for channel in channels:
-                data = image.get_data(
+                value = dask.delayed(image.get_data)(
                     timepoint=timepoint, channel=channel, delayed=True
+                )
+                data = da.from_delayed(
+                    value,
+                    shape=(image.sizeZ, image.sizeY, image.sizeX),
+                    dtype=image.dtype,
                 )
                 data_for_timepoint.append(data)
 

--- a/bioio_sldy/sldy_image.py
+++ b/bioio_sldy/sldy_image.py
@@ -36,7 +36,9 @@ class SldyImage:
     _data_paths: typing.Set[pathlib.Path] = set()
 
     @staticmethod
-    def _yaml_mapping(loader: yaml.Loader, node: yaml.Node, deep: bool = False) -> dict:
+    def _yaml_mapping(
+        loader: yaml.CLoader, node: yaml.Node, deep: bool = False
+    ) -> dict:
         """
         Static method intended to map key-value pairs found in image
         metadata yaml files to Python dictionaries.
@@ -108,7 +110,7 @@ class SldyImage:
         """
         try:
             with fs.open(yaml_path) as f:
-                return yaml.load(f, Loader=yaml.Loader)
+                return yaml.load(f, Loader=yaml.CLoader)
         except FileNotFoundError:
             if is_required:
                 raise
@@ -171,7 +173,7 @@ class SldyImage:
         yaml.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             SldyImage._yaml_mapping,
-            yaml.Loader,
+            yaml.CLoader,
         )
 
         self._fs = fs
@@ -218,6 +220,14 @@ class SldyImage:
         # Create simple sorted list of each timepoint and channel
         self.timepoints = sorted(self._timepoint_to_data_paths.keys())
         self.channels = sorted(self._channel_to_data_paths.keys())
+
+        self.sizeT = self._image_record["CImageRecord70"]["mNumTimepoints"]
+        self.sizeC = self._image_record["CImageRecord70"]["mNumChannels"]
+        self.sizeZ = self._image_record["CImageRecord70"]["mNumPlanes"]
+        self.sizeY = self._image_record["CImageRecord70"]["mHeight"]
+        self.sizeX = self._image_record["CImageRecord70"]["mWidth"]
+        # TODO check this but are all sldys uint16?  bioformats seems to say so
+        self.dtype = np.dtype(np.uint16)
 
     @property
     def metadata(self) -> typing.Dict[str, typing.Optional[dict]]:


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #15 

### Description of Changes

1. YAML loading is VERY SLOW.  Use faster yaml loader.
2. The way we constructed the delayed load array was also very (unusably) slow.  Improve use of delayed loading.

After these changes, most of the time spent is in yaml parsing.

My scratch test script looks like this:

```
from bioio_base.types import PhysicalPixelSizes
from bioio import BioImage
from bioio.plugins import dump_plugins
from bioio.writers.ome_tiff_writer import OmeTiffWriter
import bioio_sldy
import dask
import numpy
import os
from pathlib import Path

filepath = Path(
    "\\\\allen\\aics\\assay-dev\\MicroscopyData\\John Paul\\2024\\20240305\\20240305_T01_001.sldy"
)
img = BioImage(filepath, reader=bioio_sldy.Reader)
print(img.shape)
print(img.dims)
# now let's extract one timepoint
s = img.get_image_dask_data("CZYX", T=7)
print(s.shape)
t = s.compute()
print(t.shape)
```