### PR TITLE
Bugfix/41 ci failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-    with:
-      test_python_versions: '["3.13","3.12","3.11"]'
 
   # Shared lint workflow from bioio-base
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: "3.x"
       - run: pip install check-manifest && check-manifest
-  
+
   # Shared test workflow from bioio-base
   test:
     needs: [lint]
@@ -39,7 +39,7 @@ jobs:
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
 
-    # Shared lint workflow from bioio-base
+  # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,8 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-    with:
-      test_python_versions: '["3.13","3.12","3.11", "3.10"]'
-  # Shared lint workflow from bioio-base
+
+    # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
     with:
-      test_python_versions: '["3.13","3.12","3.11"]'
+      test_python_versions: '["3.13","3.12","3.11", "3.10"]'
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
+    with:
+      test_python_versions: '["3.13"]'
 
   # Shared lint workflow from bioio-base
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
+    with:
+      test_python_versions: '["3.13","3.12","3.11"]'
 
   # Shared lint workflow from bioio-base
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-
+    with:
+      test_python_versions: '["3.13","3.12","3.11"]'
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
     with:
-      test_python_versions: '["3.13"]'
+      test_python_versions: '["3.13","3.12","3.11"]'
 
   # Shared lint workflow from bioio-base
   lint:

--- a/Justfile
+++ b/Justfile
@@ -38,7 +38,7 @@ lint:
 
 # run tests
 test:
-	pytest --verbose --cov-report xml --cov-report html --cov=bioio_sldy bioio_sldy/tests
+	pytest --cov-report xml --cov-report html --cov=bioio_sldy bioio_sldy/tests
 
 # run lint and then run tests
 build:

--- a/Justfile
+++ b/Justfile
@@ -38,7 +38,7 @@ lint:
 
 # run tests
 test:
-	pytest --cov-report xml --cov-report html --cov=bioio_sldy bioio_sldy/tests
+	pytest --verbose --cov-report xml --cov-report html --cov=bioio_sldy bioio_sldy/tests
 
 # run lint and then run tests
 build:

--- a/bioio_sldy/sldy_image.py
+++ b/bioio_sldy/sldy_image.py
@@ -15,6 +15,8 @@ from fsspec.spec import AbstractFileSystem
 
 log = logging.getLogger(__name__)
 
+YAML_LOADER = getattr(yaml, "CLoader", yaml.SafeLoader)
+
 ###############################################################################
 
 
@@ -36,9 +38,7 @@ class SldyImage:
     _data_paths: typing.Set[pathlib.Path] = set()
 
     @staticmethod
-    def _yaml_mapping(
-        loader: yaml.CLoader, node: yaml.Node, deep: bool = False
-    ) -> dict:
+    def _yaml_mapping(loader: yaml.Loader, node: yaml.Node, deep: bool = False) -> dict:
         """
         Static method intended to map key-value pairs found in image
         metadata yaml files to Python dictionaries.
@@ -110,7 +110,7 @@ class SldyImage:
         """
         try:
             with fs.open(yaml_path) as f:
-                return yaml.load(f, Loader=yaml.CLoader)
+                return yaml.load(f, Loader=YAML_LOADER)
         except FileNotFoundError:
             if is_required:
                 raise
@@ -173,7 +173,7 @@ class SldyImage:
         yaml.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             SldyImage._yaml_mapping,
-            yaml.CLoader,
+            YAML_LOADER,
         )
 
         self._fs = fs


### PR DESCRIPTION
Apparently updates in underlying libraries caused some windows issues.
Using a fallback YAML loader seems to resolve it.  Would it be better to just change to yaml.SafeLoader in the first place?  I don't really know.

https://github.com/bioio-devs/bioio-sldy/issues/41

This still has variable failures, however.  PR went out after it worked 2/3 times.


[sldy_image.py:40] and [sldy_image.py:113]assume PyYAML C extensions exist by directly using yaml.CLoader.
On Windows + Python 3.13, PyYAML often installs without the C extension, so yaml.CLoader is missing.
That triggers a fast import/collection failure in pytest, which matches the 2-second Run Tests step.
Just then reports recipe failure as exit code 2816 (Windows encoding of the child non-zero exit), while GitHub surfaces exit code 1.
