### PR TITLE
Fix README example to use .sldy extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ passed in.
 from bioio import BioImage
 import bioio_sldy
 
-img = BioImage("my_file.sld", reader=bioio_sldy.Reader)
+img = BioImage("my_file.sldy", reader=bioio_sldy.Reader)
 img.data
 ```
 


### PR DESCRIPTION
## Summary
- Fixes the example in the README that incorrectly used `my_file.sld` instead of `my_file.sldy`

Closes #44