### PR TITLE
Fix CI failure from bioio-base timelapse change

### DIFF
--- a/bioio_sldy/tests/test_standard_metadata.py
+++ b/bioio_sldy/tests/test_standard_metadata.py
@@ -28,7 +28,7 @@ TEST_CASES = [
             "Pixel Size Z": None,
             "Position Index": None,
             "Row": None,
-            "Timelapse": True,
+            "Timelapse": False,
             "Timelapse Interval": datetime.timedelta(seconds=1800),
             "Total Time Duration": datetime.timedelta(
                 days=3, seconds=28800, microseconds=77000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=0.3.0",
+  "bioio-base>=3.4.0",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "numpy>=1.16,<2",


### PR DESCRIPTION
## Summary
A previous release changed the `standard_metadata` timelapse derivation in its reader from `image_size_t > 0` to `image_size_t > 1`. A single-timepoint image (T=1) now reports `Timelapse=False`, which broke CI.

## Changes
- Update `s1_t1_c2_z40` test expectation to `Timelapse=False` (T=1, matches new upstream `T > 1` logic).
- Bump `bioio-base` floor to `>=3.4.0` to keep local and CI environments in sync (this float is what let the behavior change silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)